### PR TITLE
Separate app configurations from main script

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
     <head>
         <link href="lib/bootstrap/css/bootstrap.min.css" rel="stylesheet">
         <link rel="stylesheet" type="text/css" href="css/network.css">
-        <script data-main="js/main" src="lib/require/require.js"></script>
+        <script data-main="js/app" src="lib/require/require.js"></script>
     </head>
     <body>
         <div class="container" id="main_page">

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,22 @@
+/*
+
+Application entry point if stand-alone application -- base URL to top level of this repo.
+
+*/
+
+// Config the application paths for other scripts loading modules
+
+requirejs.config({
+    baseUrl: '',
+    paths: {
+        backbone: 'lib/backbone/backbone-min',
+        bootstrap: 'lib/bootstrap/js/bootstrap.min',
+        d3: 'lib/d3/d3.min',
+        jquery: 'lib/jquery/jquery.min',
+        jqueryui: 'lib/jquery-ui/jquery-ui.min',
+        underscore: 'lib/underscore/underscore-min',
+        text: 'lib/require/text'
+    }
+})
+// Enter application through main.js
+requirejs(['js/main']);

--- a/js/main.js
+++ b/js/main.js
@@ -1,24 +1,3 @@
-/*
-
-Application entry point.
-
-*/
-
-// Config the application paths for other scripts loading modules
-
-requirejs.config({
-    baseUrl: '',
-    paths: {
-        backbone: 'lib/backbone/backbone-min',
-        bootstrap: 'lib/bootstrap/js/bootstrap.min',
-        d3: 'lib/d3/d3.min',
-        jquery: 'lib/jquery/jquery.min',
-        jqueryui: 'lib/jquery-ui/jquery-ui.min',
-        underscore: 'lib/underscore/underscore-min',
-        text: 'lib/require/text'
-    }
-})
-
 // Main application single entry point
 requirejs([
     'jquery',


### PR DESCRIPTION
The point of this PR is to allow for custom entry-points into NetworkViewer. specifically for the case when  the application is not stand alone. 

i.e. Loading the applications into a Reveal.js slide requires a different baseURL for loading require modules. Need to allow these configurations to be set externally from the app. 